### PR TITLE
Docs folder index

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,13 +193,15 @@ will be returned to the list of reports for this connection.
 
 ## Other Guides
 
- * [Scheduling Reports](/docs/scheduling.md)
+  * [Scheduling Reports](/docs/scheduling.md)
  * [Sharing Individual Reports](/docs/sharing.md)
  * [Team Management](/docs/teams.md)
  * [The Advanced Query Builder](/docs/advanced.md)
  * [Auto Join](/docs/autojoin.md)
  * [Customizing QueryTree](/docs/customizing.md)
  * [Building a password manager](/docs/password-manager.md)
+ * [Using with Docker](/docs/docker.md)
+ * [Configuring Email](/docs/mail.md)
 
 ## License
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -8,4 +8,4 @@
  * [Customizing QueryTree](/docs/customizing.md)
  * [Building a password manager](/docs/password-manager.md)
  * [Using with Docker](/docs/docker.md)
- * [Configuring Email](/docs/email.md)
+ * [Configuring Email](/docs/mail.md)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,11 @@
+## QueryTree Guides and Docs
+
+ * [Scheduling Reports](/docs/scheduling.md)
+ * [Sharing Individual Reports](/docs/sharing.md)
+ * [Team Management](/docs/teams.md)
+ * [The Advanced Query Builder](/docs/advanced.md)
+ * [Auto Join](/docs/autojoin.md)
+ * [Customizing QueryTree](/docs/customizing.md)
+ * [Building a password manager](/docs/password-manager.md)
+ * [Using with Docker](/docs/docker.md)
+ * [Configuring Email](/docs/email.md)


### PR DESCRIPTION
Creating a readme in the docs folder that displays in GitHub when you navigate to the /docs folder. Showing a nice index of the docs available.

Also updated the docs listed on the main README