### PR TITLE
Fixes #51

### DIFF
--- a/Web/Views/Simple/Edit.cshtml
+++ b/Web/Views/Simple/Edit.cshtml
@@ -114,7 +114,7 @@
                 <select class="form-control" name="Column" data-bind="options: AllInputColumnInfos, optionsText: 'Name', optionsValue: 'Index', value: FilterColumnIndex"></select>
             </div>
             <div class="form-group">
-                <select id="Operator" name="Operator" class="form-control" data-bind="options: ValidOperators, optionsText: 'simpleName', optionsValue: 'name',  value: Operator"></select>
+                <select id="Operator" name="Operator" class="form-control" data-bind="options: ValidOperators, optionsText: 'simpleName', optionsValue: 'type',  value: Operator"></select>
             </div>
             @*<div class="form-group">
                     <select class="form-control" name="CompareColumn" data-bind="options: AllInputColumnsPlusEnteredValue, optionsText: 'Name', optionsValue: 'Index', value: FilterCompareColumnIndex, visible: ShowFilterCompareValue"></select>


### PR DESCRIPTION
Makes the operator selector field use `type` as `optionsValue`, just like in `Create.cshtml`, which actually does work.