### PR TITLE
Modified FK-finding code in DbManager to prevent exceptions when there are multiple tables with the same name in different schemas

### DIFF
--- a/Web/Managers/DbManager.cs
+++ b/Web/Managers/DbManager.cs
@@ -397,7 +397,10 @@ namespace QueryTree.Managers
                 }
             }
 
-            var tableByIdName = dbModel.Tables.ToDictionary(t => t.Name.ToLower() + "id");
+            var tableByIdName = dbModel.Tables
+                .GroupBy(t => t.Name.ToLower())
+                .ToDictionary(group => group.Key + "id",
+                              items => items.First());
 
             foreach (var table in dbModel.Tables)
             {


### PR DESCRIPTION
With the following tables: dbo.tableName, abc.tableName
dbModel.Tables.ToDictionary throws a System.ArgumentException: "An item with the same key has already been added".  This prevents the table list from loading, making QueryTree unusable for the entire database.
Grouping tables by name and selecting the first item from each group avoids this and allows QueryTree to be used :)