### PR TITLE
removed suffix from database type before check

### DIFF
--- a/Web/Scripts/tools.js
+++ b/Web/Scripts/tools.js
@@ -351,6 +351,8 @@ tools.IsDatetimeType = function (theType) {
 }
 
 tools.IsTextType = function (theType) {
+    let regex = /\([0-9]*\)$/;
+    theType = theType.replace(regex, '');
     switch (theType.toUpperCase()) {
         case "VARCHAR":
         case "NVARCHAR":


### PR DESCRIPTION
When for example the database returns the column Type in a form like 'character varying(256)' the suffix caused the filter selection for textvalues not to show up.  

The Testdatabase was postgresql 9.6.