### PR TITLE
(docker) expose port 80 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,5 @@ VOLUME /var/lib/querytree
 ENV ConnectionStrings__DefaultConnection="Filename=/var/lib/querytree/querytree.db;"
 ENV Passwords__Keyfile="/var/lib/querytree/querytree.key"
 CMD dotnet QueryTree.dll
+
+EXPOSE 80


### PR DESCRIPTION
Some Kubenetes platform like Openshift will use that value to create a service automatically.